### PR TITLE
valueOf/valuesOf for radiobutton behaves similar to checkbox

### DIFF
--- a/dist/test-utils.js
+++ b/dist/test-utils.js
@@ -314,8 +314,8 @@ exports.expectThat = {
     location: assertion(location),
     textOf: first(function (e) { return e.textContent.trim(); }),
     textsOf: all(function (e) { return e.textContent.trim(); }),
-    valueOf: first(function (e) { return (e.type === "checkbox" ? e.checked : e.value); }),
-    valuesOf: all(function (e) { return (e.type === "checkbox" ? e.checked : e.value); })
+    valueOf: first(function (e) { return ((e.type === "checkbox" || e.type === "radio") ? e.checked : e.value); }),
+    valuesOf: all(function (e) { return ((e.type === "checkbox" || e.type === "radio") ? e.checked : e.value); })
 };
 function find(fixture, selector) {
     var compontent = fixture.nativeElement;

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,9 +1,8 @@
 import * as _ from "lodash";
 
 import { Location } from "@angular/common";
-import { DebugElement, EventEmitter, Type } from "@angular/core";
+import { EventEmitter, Type } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
-import { By } from "@angular/platform-browser";
 import { Router } from "@angular/router";
 
 export { http } from "./server";
@@ -364,8 +363,8 @@ export const expectThat = {
   location: assertion(location),
   textOf: first((e) => e.textContent.trim()),
   textsOf: all((e) => e.textContent.trim()),
-  valueOf: first((e: HTMLInputElement) => (e.type === "checkbox" ? e.checked : e.value)),
-  valuesOf: all((e: HTMLInputElement) => (e.type === "checkbox" ? e.checked : e.value))
+  valueOf: first((e: HTMLInputElement) => ((e.type === "checkbox" || e.type === "radio") ? e.checked : e.value)),
+  valuesOf: all((e: HTMLInputElement) => ((e.type === "checkbox" || e.type === "radio") ? e.checked : e.value))
 };
 
 function find(fixture: ComponentFixture<any>, selector: string): SearchableElement {

--- a/test/component/app.component.html
+++ b/test/component/app.component.html
@@ -1,6 +1,6 @@
 <h1 class="title"> {{title}} </h1>
 <input #nameInput class="name" [(ngModel)]="name">
-<input id="checkbox" type="checkbox" [(ngModel)]="checkboxValue"> I agree to the terms<br>
+<input id="checkbox" type="checkbox" [(ngModel)]="checkboxValue" value="Example"> I agree to the terms<br>
 <div class="greeting">{{message}}</div>
 <div id="editor" contenteditable="true">This needs to be edited!</div>
 <button id="hello" (click)="sayHello()">Say hello</button>
@@ -15,3 +15,7 @@
     <text class="label">Text in SVG</text>
   </g>
 </svg>
+<form>
+  <input id="radiobutton1" type="radio" name="gender" value="male">Male<br>
+  <input id="radiobutton2" type="radio" name="gender" value="female">Female<br>
+</form>

--- a/test/component/sample-test.spec.ts
+++ b/test/component/sample-test.spec.ts
@@ -89,7 +89,36 @@ describe("Manager Component", () => {
         );
 
         comp.verify(
-            expectThat.valueOf("#checkbox").isEqualTo(true)
+            expectThat.valueOf("#checkbox").isEqualTo(true),
+            expectThat.attributeOf("#checkbox", "value").isEqualTo("Example")
+        );
+    });
+
+    it("valueOf for radiobutton returns true for checked one", () => {
+        const comp = app.run(AppComponent);
+
+        comp.perform(
+            check.in("#radiobutton2")
+        );
+
+        comp.verify(
+            expectThat.valueOf("#radiobutton1").isEqualTo(false),
+            expectThat.valueOf("#radiobutton2").isEqualTo(true),
+            expectThat.valuesOf("input[type='radio']").areEqualTo([false, true])
+        );
+    });
+
+    it("attributeOf for radiobutton returns 'value'", () => {
+        const comp = app.run(AppComponent);
+
+        comp.perform(
+            check.in("#radiobutton2")
+        );
+
+        comp.verify(
+            expectThat.attributeOf("#radiobutton1", "value").isEqualTo("male"),
+            expectThat.attributeOf("#radiobutton2", "value").isEqualTo("female"),
+            expectThat.attributesOf("input[type='radio']", "value").areEqualTo(["male", "female"])
         );
     });
 
@@ -99,7 +128,7 @@ describe("Manager Component", () => {
         comp.verify(
             expectThat.textsOf("div").areEqualTo(["nothing yet", "This needs to be edited!"]),
             expectThat.cssClassesOf("div").contain("greeting"),
-            expectThat.valuesOf("input").areEqualTo(["", false]),
+            expectThat.valuesOf("input").areEqualTo(["", false, false, false]),
             expectThat.elements("h1").haveSize(1),
             expectThat.attributesOf("button", "id").areEqualTo(["hello", "goodbye"]),
             expectThat.attributesOf("button", "missing").isEmpty()


### PR DESCRIPTION
Currently methods `valueOf/valuesOf` is inconsistent for checkbox and radiobutton. For checkbox it returns `checked` attribute, but for radiobutton it returns `value` attribute.

This PR adds for radiobutton same behaviour as it was for checkbox.
