### PR TITLE
Support for EventEmitter with simple name

### DIFF
--- a/dist/test-utils.js
+++ b/dist/test-utils.js
@@ -35,7 +35,7 @@ function run(component, inputs, outputs) {
     var componentInstance = fixture.componentInstance;
     _.merge(componentInstance, inputs);
     _.each(outputs, function (listener, property) {
-        var emitter = componentInstance[property + "Change"];
+        var emitter = (componentInstance[property] || componentInstance[property + "Change"]);
         if (emitter) {
             emitter.subscribe(listener);
         }

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -38,7 +38,7 @@ function run(component: Type<any>, inputs: any = {}, outputs: any = {}): Fixture
   const componentInstance = fixture.componentInstance;
   _.merge(componentInstance, inputs);
   _.each(outputs, (listener, property) => {
-    const emitter = componentInstance[property + "Change"] as EventEmitter<any>;
+    const emitter = (componentInstance[property] || componentInstance[property + "Change"]) as EventEmitter<any>;
     if (emitter) {
       emitter.subscribe(listener);
     }

--- a/test/component/app.component.html
+++ b/test/component/app.component.html
@@ -15,3 +15,4 @@
     <text class="label">Text in SVG</text>
   </g>
 </svg>
+<span id="clickable" (click)="clicked()"></span>

--- a/test/component/app.component.ts
+++ b/test/component/app.component.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from "@angular/common/http";
-import { Component, HostListener, ViewChild } from "@angular/core";
+import { Component, EventEmitter, HostListener, Output, ViewChild } from "@angular/core";
 
 @Component({
   selector: "app-root",
@@ -13,6 +13,10 @@ export class AppComponent {
   public status = "";
   @ViewChild("nameInput")
   public nameInput;
+  @Output()
+  public emitted = new EventEmitter<string>();
+  @Output()
+  public bananaStyleChange = new EventEmitter<string>();
 
   private title = "Fancy title!";
   private label = "";
@@ -40,5 +44,10 @@ export class AppComponent {
     if (this.nameInput.nativeElement === target && key.toLowerCase() === "enter") {
       this.sayHello();
     }
+  }
+
+  public clicked() {
+    this.emitted.emit('supports simple name');
+    this.bananaStyleChange.emit('supports banana syntax');
   }
 }

--- a/test/component/sample-test.spec.ts
+++ b/test/component/sample-test.spec.ts
@@ -149,4 +149,30 @@ describe("Manager Component", () => {
       );
     });
 
+    it('should emit event for standard output name', () => {
+        let received;
+        const comp = app.run(AppComponent, {}, {emitted: (v: string) => received = v});
+
+        comp.perform(
+            click.in('#clickable')
+        );
+
+        comp.verify(
+            () => expect(received).toEqual('supports simple name')
+        );
+    });
+
+    it('should emit event for banana name [( )] - aka ngModel style', () => {
+        let received;
+        const comp = app.run(AppComponent, {}, {bananaStyle: (v: string) => received = v});
+
+        comp.perform(
+            click.in('#clickable')
+        );
+
+        comp.verify(
+            () => expect(received).toEqual('supports banana syntax')
+        );
+    });
+
 });


### PR DESCRIPTION
Currently library only supports `EventEmitter` for property that has name with suffix `Change`. See:
https://github.com/Pragmatists/ng-test-runner/blob/master/src/test-utils.ts#L41

So currently we cannot test outputs for this example: https://angular.io/api/core/EventEmitter#examples

This PR adds support for this case.