### PR TITLE
Throw error when selector matches more than one element and optional generic types for Req body and params

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -13,9 +13,9 @@ export interface Server {
   stop(): void;
 }
 
-export interface Req<T = any> {
+export interface Req<T = any, P = any> {
   body(): T;
-  query(): any;
+  query(): P;
   header(name: string): string;
   sendJson(json: any, headers?: any): void;
   sendStatus(status: number, json?: any, headers?: any): void;

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,8 +13,8 @@ export interface Server {
   stop(): void;
 }
 
-export interface Req {
-  body(): string;
+export interface Req<T = any> {
+  body(): T;
   query(): any;
   header(name: string): string;
   sendJson(json: any, headers?: any): void;

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -381,10 +381,6 @@ function find(fixture: ComponentFixture<any>, selector: string): SearchableEleme
 function findAll(fixture: ComponentFixture<any>, selector: string): SearchableElement[] {
   const component = fixture.nativeElement as SearchableElement;
   const elements = component.querySelectorAll(selector);
-
-  const result = [];
-  for (let i = 0; i < elements.length; i++) {
-    result.push(elements.item(i));
-  }
-  return result;
+  return _.range(elements.length)
+      .map(idx => elements.item(idx) as SearchableElement);
 }

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -4,8 +4,6 @@ import { EventEmitter, Type } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
 
-export { http } from './server';
-
 export type Action = (fixture: ComponentFixture<any>) => Promise<any> | any;
 
 export interface Fixture {
@@ -370,11 +368,14 @@ export const expectThat = {
 
 function find(fixture: ComponentFixture<any>, selector: string): SearchableElement {
   const component = fixture.nativeElement as SearchableElement;
-  const element = component.querySelector<SearchableElement>(selector);
-  if (element) {
-    return element;
+  const elements = component.querySelectorAll<SearchableElement>(selector);
+  if (elements.length === 1) {
+    return elements[0];
+  } else if (elements.length > 1) {
+    throw new Error(`${elements.length} elements match ${selector} selector!`);
+  } else {
+    throw new Error(`Could not find ${selector} element!`);
   }
-  throw new Error(`Could not find ${selector} element!`);
 }
 
 function findAll(fixture: ComponentFixture<any>, selector: string): SearchableElement[] {

--- a/test/app.module.ts
+++ b/test/app.module.ts
@@ -2,11 +2,11 @@ import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpClientModule } from '@angular/common/http';
 import { BrowserModule } from '@angular/platform-browser';
-import { AppComponent } from './app.component';
+import { AppComponent } from './component/app.component';
+import { HttpComponent } from './http/http.component';
 
 @NgModule({
-  bootstrap: [AppComponent],
-  declarations: [AppComponent],
+  declarations: [AppComponent, HttpComponent],
   imports: [BrowserModule, FormsModule, HttpClientModule]
 })
 export class AppModule {}

--- a/test/component/app.component.html
+++ b/test/component/app.component.html
@@ -1,14 +1,9 @@
 <h1 class="title"> {{title}} </h1>
 <input #nameInput class="name" [(ngModel)]="name" (blur)="onLeaveNameInput()">
 <input id="checkbox" type="checkbox" [(ngModel)]="checkboxValue" value="Example"> I agree to the terms<br>
-<div class="greeting">{{message}}</div>
+<div data-message class="greeting message">{{message}}</div>
 <div id="editor" contenteditable="true">This needs to be edited!</div>
 <button id="hello" (click)="sayHello()">Say hello</button>
-<button id="goodbye" class="goodbye" (click)="sayGoodbye()">Say goodbye</button>
-<form (ngSubmit)="update()">
-    <span id="status">{{status}}</span>
-    <span id="token">{{token}}</span>
-</form>
 <svg>
   <g>
     <rect class="box" x="10" y="20"></rect>
@@ -21,4 +16,3 @@
   <input id="radiobutton2" type="radio" name="gender" value="female">Female<br>
 </form>
 <span id="clickable" (click)="clicked()"></span>
-<span id="get" (click)="sendGet()">Send GET</span>

--- a/test/component/app.component.ts
+++ b/test/component/app.component.ts
@@ -1,6 +1,4 @@
-import { HttpClient } from '@angular/common/http';
-import { Component, EventEmitter, HostListener, Output, ViewChild } from '@angular/core';
-import { noop } from 'lodash';
+import {Component, EventEmitter, HostListener, Output, ViewChild} from '@angular/core';
 
 @Component({
   selector: 'app-root',
@@ -11,39 +9,16 @@ export class AppComponent {
   public name = '';
   public message = 'nothing yet';
   public checkboxValue = false;
-  public status = '';
-  public token;
   @ViewChild('nameInput')
   public nameInput;
   @Output()
   public emitted = new EventEmitter<string>();
   @Output()
-  public bananaStyleChange = new EventEmitter<string>();
-  @Output()
   public capitalizedName = new EventEmitter<string>();
-
-  private title = 'Fancy title!';
-  private label = '';
-
-  constructor(private http: HttpClient) {}
-
-  public edit() {
-    this.label = 'Wojtek';
-  }
+  public title = 'Fancy title!';
 
   public sayHello() {
     this.message = `Hello ${this.name}!`;
-  }
-
-  public sayGoodbye() {
-    this.http.post<any>('/goodbye', {}, {observe: 'response'}).subscribe((resp) => {
-        this.message = resp.body.message;
-        this.token = resp.headers.get('token');
-    });
-  }
-
-  public update() {
-    this.http.put<any>('/update', {}).subscribe(({ message }) => (this.status = message));
   }
 
   @HostListener('window:keydown', ['$event.target', '$event.key'])
@@ -55,14 +30,9 @@ export class AppComponent {
 
   public clicked() {
     this.emitted.emit('supports simple name');
-    this.bananaStyleChange.emit('supports banana syntax');
   }
 
   public onLeaveNameInput() {
     this.capitalizedName.emit(this.name.toUpperCase());
-  }
-
-  public sendGet() {
-      this.http.get('/api/test/1').subscribe(noop, noop);
   }
 }

--- a/test/component/sample-test.spec.ts
+++ b/test/component/sample-test.spec.ts
@@ -1,20 +1,13 @@
-import test, {App, blur, check, click, expectThat, http, keydown, Server, submit, type} from '../../src/index';
+import test, {App, blur, check, click, expectThat, keydown, type} from '../../src/index';
 import {AppComponent} from './app.component';
-import {AppModule} from './app.module';
+import {AppModule} from '../app.module';
 import {async} from '@angular/core/testing';
 
 describe('Manager Component', () => {
-
     let app: App;
-    let server: Server;
 
     beforeEach(() => {
         app = test(AppModule);
-        server = http();
-    });
-
-    afterEach(() => {
-        server.stop();
     });
 
     it('initial value', async(() => {
@@ -48,33 +41,6 @@ describe('Manager Component', () => {
 
         comp.verify(
             expectThat.textOf('.greeting').isEqualTo('Hello John!')
-        );
-    }));
-
-    it('goodbye server response', async(() => {
-        const comp = app.run(AppComponent);
-        server.post('/goodbye', req => req.sendJson({message: 'Goodbye Jane!'}));
-
-        comp.perform(
-            click.in('button.goodbye')
-        );
-
-        comp.verify(
-            expectThat.textOf('.greeting').isEqualTo('Goodbye Jane!')
-        );
-    }));
-
-    it('goodbye server token', async(() => {
-        const comp = app.run(AppComponent);
-        server.post('/goodbye', req =>
-            req.sendResponse(200, JSON.stringify({message: 'Goodbye Jane!'}), {token: 'someToken'}));
-
-        comp.perform(
-            click.in('button.goodbye')
-        );
-
-        comp.verify(
-            expectThat.textOf('#token').isEqualTo('someToken')
         );
     }));
 
@@ -139,15 +105,25 @@ describe('Manager Component', () => {
         );
     }));
 
+    it('allows to verify with single syntax', async(() => {
+        const component = app.run(AppComponent);
+
+        component.verify(
+            expectThat.cssClassesOf('[data-message]').isNotEmpty(),
+            expectThat.cssClassesOf('[data-message]').haveSize(2),
+            expectThat.cssClassesOf('[data-message]').contain('greeting'),
+            expectThat.cssClassesOf('[data-message]').doNotContain('someClass')
+        );
+    }));
+
     it('allows to verify with plural syntax', async(() => {
         const comp = app.run(AppComponent);
 
         comp.verify(
             expectThat.textsOf('div').areEqualTo(['nothing yet', 'This needs to be edited!']),
-            expectThat.cssClassesOf('div').contain('greeting'),
             expectThat.valuesOf('input').areEqualTo(['', false, false, false]),
             expectThat.elements('h1').haveSize(1),
-            expectThat.attributesOf('button', 'id').areEqualTo(['hello', 'goodbye']),
+            expectThat.attributesOf('input', 'id').areEqualTo(['checkbox', 'radiobutton1', 'radiobutton2']),
             expectThat.attributesOf('button', 'missing').isEmpty()
         );
     }));
@@ -161,38 +137,25 @@ describe('Manager Component', () => {
         );
     }));
 
-    it('submit form to update status', async(() => {
-        const comp = app.run(AppComponent);
-        server.put('/update', req => req.sendJson({message: 'Updated!'}));
-
-        comp.perform(
-            submit.form('form')
-        );
-
-        comp.verify(
-            expectThat.textOf('#status').isEqualTo('Updated!')
-        );
-    }));
-
     it('check attribute value of an element', async(() => {
 
-      const comp = app.run(AppComponent);
+        const comp = app.run(AppComponent);
 
-      comp.verify(
-          expectThat.attributeOf('#editor', 'contenteditable').isEqualTo('true'),
-          expectThat.attributeOf('#editor', 'missing').doesNotExist()
-      );
+        comp.verify(
+            expectThat.attributeOf('#editor', 'contenteditable').isEqualTo('true'),
+            expectThat.attributeOf('#editor', 'missing').doesNotExist()
+        );
     }));
 
     it('check text & attributes of svg elements', async(() => {
 
-      const comp = app.run(AppComponent);
+        const comp = app.run(AppComponent);
 
-      comp.verify(
-          expectThat.attributeOf('rect.box', 'x').isEqualTo('10'),
-          expectThat.textOf('text.label').isEqualTo('Text in SVG'),
-          expectThat.attributesOf('rect', 'class').areEqualTo(['box', 'rectangle'])
-      );
+        comp.verify(
+            expectThat.attributeOf('rect.box', 'x').isEqualTo('10'),
+            expectThat.textOf('text.label').isEqualTo('Text in SVG'),
+            expectThat.attributesOf('rect', 'class').areEqualTo(['box', 'rectangle'])
+        );
     }));
 
     it('should emit event for standard output name', async(() => {
@@ -208,19 +171,6 @@ describe('Manager Component', () => {
         );
     }));
 
-    it('should emit event for banana name [( )] - aka ngModel style', async(() => {
-        let received;
-        const comp = app.run(AppComponent, {}, {bananaStyle: (v: string) => received = v});
-
-        comp.perform(
-            click.in('#clickable')
-        );
-
-        comp.verify(
-            () => expect(received).toEqual('supports banana syntax')
-        );
-    }));
-
     it('after leaving name input upper case value should be emitted', async(() => {
         let output;
         const comp = app.run(AppComponent, {}, {capitalizedName: (v: string) => output = v});
@@ -232,23 +182,6 @@ describe('Manager Component', () => {
 
         comp.verify(
             () => expect(output).toEqual('FOO BAR')
-        );
-    }));
-
-    it('should pass request params to handler', async((done) => {
-        let receivedId;
-        server.get(/api\/test\/(\d+)/, (req, id) => {
-            receivedId = id;
-            req.sendStatus(200);
-        });
-        const comp = app.run(AppComponent);
-
-        comp.perform(
-            click.in('#get')
-        );
-
-        comp.verify(
-            () => expect(receivedId).toEqual('1')
         );
     }));
 

--- a/test/http/http.component.html
+++ b/test/http/http.component.html
@@ -1,0 +1,20 @@
+<div>
+  <div data-username>{{username}}</div>
+  <div>
+    <button data-greeting-button (click)="onGreetingClick()">Greeting</button>
+    <div data-greeting-message>{{greetingMessage}}</div>
+    <div data-greeting-token>{{greetingToken}}</div>
+  </div>
+  <form (ngSubmit)="onUpdateUserClick()" data-update-user>
+    <div data-update-status>{{updateStatus}}</div>
+  </form>
+  <div>
+    <button data-fetch-users (click)="onFetchUsersClick()">Users list</button>
+    <div>
+      <div *ngFor="let user of users" data-user-item>
+        <div data-id>{{user.id}}</div>
+        <div data-name>{{user.name}}</div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/test/http/http.component.spec.ts
+++ b/test/http/http.component.spec.ts
@@ -1,0 +1,137 @@
+import {HttpComponent} from './http.component';
+import test, {App, click, expectThat, http, Req, Server, submit} from '../../src';
+import {AppModule} from '../app.module';
+import {async} from '@angular/core/testing';
+import {includes} from 'lodash';
+
+describe('HTTP Server', () => {
+    let app: App;
+    let server: Server;
+
+    beforeEach(() => {
+        app = test(AppModule);
+        server = http();
+        withUserDetails();
+    });
+
+    afterEach(() => {
+        server.stop();
+    });
+
+    it('responds with username based on path variable', async(() => {
+        const component = app.run(HttpComponent, {userId: 1});
+
+        component.verify(
+            expectThat.textOf(username()).isEqualTo('Jim')
+        );
+    }));
+
+    it('should respond with username provided in request body', async(() => {
+        server.post(
+            '/greeting',
+            req => req.sendJson({message: `Hello ${req.body().name}!`})
+        );
+        const component = app.run(HttpComponent, {userId: 1});
+
+        component.perform(
+            click.in(greetingButton())
+        );
+
+        component.verify(
+            expectThat.textOf(greetingMessage()).isEqualTo('Hello Jim!')
+        );
+    }));
+
+    it('sends back token passed in headers', async(() => {
+        server.post(
+            '/greeting',
+            req => req.sendJson(
+                {},
+                {token: req.header('token')}
+            )
+        );
+        const component = app.run(HttpComponent, {userId: 1});
+
+        component.perform(
+            click.in(greetingButton())
+        );
+
+        component.verify(
+            expectThat.textOf(greetingToken()).isEqualTo('greeting token')
+        );
+    }));
+
+    it('should return custom HTTP status on form submit', async(() => {
+        server.put('/me', req => req.sendStatus(204));
+        const component = app.run(HttpComponent, {userId: 1});
+
+        component.perform(
+            submit.form(updateUserForm())
+        );
+
+        component.verify(
+            expectThat.textOf(updateStatus()).isEqualTo('204')
+        );
+    }));
+
+    it('should filter users by query param', async(() => {
+        server.get(/\/users\?.*/, (req: Req<{}, { name: string }>) => {
+            const users = [
+                {name: 'John Doe', id: 1},
+                {name: 'Tom Hanks', id: 2},
+                {name: 'John Brown', id: 3}
+            ];
+            const nameFilter = req.query().name;
+            const filtered = users.filter(user => includes(user.name, nameFilter));
+            req.sendJson(filtered);
+        });
+        const component = app.run(HttpComponent, {userId: 1});
+
+        component.perform(
+            click.in(fetchUsersButton())
+        );
+
+        component.verify(
+            expectThat.textsOf(`${userListItem()} [data-id]`).areEqualTo(['1', '3'])
+        );
+    }));
+
+    function greetingButton() {
+        return '[data-greeting-button]';
+    }
+
+    function greetingMessage() {
+        return '[data-greeting-message]';
+    }
+
+    function greetingToken() {
+        return '[data-greeting-token]';
+    }
+
+    function username() {
+        return '[data-username]';
+    }
+
+    function updateUserForm() {
+        return '[data-update-user]';
+    }
+
+    function updateStatus() {
+        return '[data-update-status]';
+    }
+
+    function fetchUsersButton() {
+        return '[data-fetch-users]';
+    }
+
+    function userListItem() {
+        return '[data-user-item]';
+    }
+
+    function withUserDetails() {
+        const users = {
+            1: {name: 'Jim'}
+        };
+        server.get(/\/users\/(\d+)\/details/, (req, id) => req.sendJson(users[id]));
+    }
+});

--- a/test/http/http.component.ts
+++ b/test/http/http.component.ts
@@ -1,0 +1,64 @@
+import {Component, Input, OnInit} from '@angular/core';
+import {HttpClient, HttpResponse} from '@angular/common/http';
+import {map} from 'rxjs/operators';
+
+interface GreetingResponse {
+    message: string;
+}
+
+interface UserDetailsResponse {
+    name: string;
+}
+
+interface UserResponse {
+    name: string;
+    id: number;
+}
+
+@Component({
+    selector: 'http',
+    templateUrl: './http.component.html'
+})
+export class HttpComponent implements OnInit {
+    public username;
+    public greetingMessage: string;
+    public greetingToken: string;
+    public updateStatus: number;
+    public users: UserResponse[] = [];
+
+    @Input()
+    public userId: number;
+
+    constructor(private readonly http: HttpClient) {
+    }
+
+    public ngOnInit(): void {
+        this.http.get<UserDetailsResponse>(`/users/${this.userId}/details`)
+            .subscribe(({name}) => this.username = name);
+    }
+
+    public onGreetingClick() {
+        this.http.post<GreetingResponse>(
+            '/greeting',
+            {name: 'Jim'},
+            {headers: {token: 'greeting token'}, observe: 'response'}
+        ).subscribe(response => this.onGreetingResponse(response));
+    }
+
+    public onUpdateUserClick() {
+        this.http.put('/me', {name: 'Tom'}, {observe: 'response'}).pipe(
+            map(response => response.status)
+        ).subscribe(status => this.updateStatus = status);
+    }
+
+    public onFetchUsersClick() {
+        this.http.get<UserResponse[]>('/users', {params: {name: 'John'}})
+            .subscribe(users => this.users = users);
+    }
+
+    private onGreetingResponse(response: HttpResponse<GreetingResponse>) {
+        const {body, headers} = response;
+        this.greetingMessage = body.message;
+        this.greetingToken = headers.get('token');
+    }
+}

--- a/test/main.ts
+++ b/test/main.ts
@@ -1,5 +1,5 @@
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
-import { AppModule } from './component/app.module';
+import { AppModule } from './app.module';
 
 platformBrowserDynamic().bootstrapModule(AppModule);


### PR DESCRIPTION
- Fix for [#1](https://github.com/Pragmatists/ng-test-runner/issues/1)
- Req body and query params with optional generic types
- Http tests extracted to different component
- Test case `should emit event for banana name [( )] - aka ngModel style` has been removed, because it's a duplication of `should emit event for standard output name`